### PR TITLE
fix(run-tests): use function only if we don't have testRegex and test…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serverless Jest Plugin
+# Serverless Jest Plugin - FORKED
 
 [![Build Status](https://travis-ci.org/nordcloud/serverless-jest-plugin.svg?branch=master)](https://travis-ci.org/nordcloud/serverless-jest-plugin)
 

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -13,8 +13,7 @@ const runTests = (serverless, options, conf) =>
     const vars = new serverless.classes.Variables(serverless);
     vars.populateService(options);
     allFunctions.forEach(name => setEnv(serverless, name));
-
-    if (!config.testRegex) {
+    if (!config.testRegex && !config.testMatch) {
       if (functionName) {
         if (allFunctions.indexOf(functionName) >= 0) {
           setEnv(serverless, functionName);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "serverless-jest-plugin",
+  "name": "@zarconontol/serverless-jest-plugin",
   "version": "0.3.0",
   "description": "Serverless plugin for test driven development using Jest",
   "main": "index.js",
@@ -33,6 +33,16 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.9.0",
     "serverless": "^1.32.0",
-    "strip-ansi": "chalk/strip-ansi"
-  }
+    "strip-ansi": "github:chalk/strip-ansi"
+  },
+  "directories": {
+    "lib": "lib"
+  },
+  "keywords": [
+    "serverless",
+    "serverless-offline",
+    "serverless-jest",
+    "jest",
+    "serverless.yml"
+  ]
 }


### PR DESCRIPTION
…Match config


For our project we are using the following config in the serverless.yml: 
```
jest:
    testMatch: ['**/__tests__/*.(unit|int|e2e)-spec.ts']
```

Since we wanted to use testMatch instead of testRegex because of the standards of our projects, we weren't able to use it properly. We are using NestJS as framework.

Please let me know if you have any questions!

Thanks.

