### PR TITLE
Accept shortcut version of single-function test invocation

### DIFF
--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -6,7 +6,7 @@ const { setEnv } = require('./utils');
 
 const runTests = (serverless, options, conf) =>
   new BbPromise((resolve, reject) => {
-    const functionName = options.function;
+    const functionName = options.f || options.function;
     const allFunctions = serverless.service.getAllFunctions();
     const config = Object.assign({ testEnvironment: 'node' }, conf);
 


### PR DESCRIPTION
In newer versions of serverless, the `options` no longer contains the mapping from the shortcut to the longer option name, so they must both be explicitly checked for. This style is already used in `create-test.js`, for example, but just happens to be missing in `run-tests.js`.

**Without** this change, running `sls invoke test -f blah` ends up running *all* tests, while `sls invoke test --function blah` works as expected.